### PR TITLE
Add Igly to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 [Crowdfunding.ai](https://crowdfunding.ai/) — crowdfunding platform for AI projects
 [Fiddler Guardrails](https://fiddler.ai/guardrails-trial) - free LLM guardrails
 [Fieldguide](https://fieldguide.net/) — universal field guide that suggests possible matches
+[Igly](https://igly.ai/) — AI image editor for background removal, object removal, upscaling, restoration, and product photo workflows
 
 ## Books
 


### PR DESCRIPTION
Added Igly to the Tools section as a free AI image editor with infinite canvas.

It brings 12+ tools into one place, including background removal, background replacement, image upscale, photo restoration, AI inpainting, and image generation.

Website: https://igly.ai
