### PR TITLE
Add Punch Needle Generator to Image Generation & Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Canva Magic Studio**](https://www.canva.com/magic-studio/) — AI design tools.
 * [**Figma AI / Make**](https://www.figma.com/ai/) — AI in Figma.
 * [**Photoshop Firefly**](https://www.adobe.com/products/photoshop/ai.html) — Adobe's generative fill.
+* [**Punch Needle Generator**](https://www.punchneedle.co.il/en) — AI-generated punch needle embroidery patterns with color-coded yarn maps from text prompts or image uploads.
 
 ### Video & Audio
 


### PR DESCRIPTION
Adds Punch Needle Generator under **Specialized AI Tools > Image Generation & Design**.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Description:** AI-generated punch needle embroidery patterns with color-coded yarn maps from text prompts or image uploads.

Per CONTRIBUTING:
- One line, factual description, no marketing language.
- Project has been live more than 30 days.
- Format matches section style: `* [**Name**](url) — description.`
- I'm the maintainer of the tool.