### PR TITLE
Add Future AGI to LLM Ops & Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**OpenLIT**](https://openlit.io/) — OpenTelemetry-native LLM observability.
 * [**Opik (Comet)**](https://github.com/comet-ml/opik) 🆕 — open-source LLM eval + tracing.
 * [**Inspect AI**](https://inspect.aisi.org.uk/) 🆕 — UK AISI's agent eval framework.
+* [**Future AGI**](https://github.com/future-agi/future-agi) 🆕 — open-source platform for agent simulation, evaluating, tracing, guarding, and auto-improving AI agents.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [Future AGI](https://github.com/future-agi/future-agi) to LLM Ops & Observability
- Open-source self-hostable LLMOps platform unifying tracing, evals, simulations, datasets, gateway, and guardrails — peer of Langfuse, Helicone, Phoenix, Braintrust, Promptfoo, OpenLIT, Opik