### PR TITLE
Add igly.ai to Image Generation & Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Canva Magic Studio**](https://www.canva.com/magic-studio/) — AI design tools.
 * [**Figma AI / Make**](https://www.figma.com/ai/) — AI in Figma.
 * [**Photoshop Firefly**](https://www.adobe.com/products/photoshop/ai.html) — Adobe's generative fill.
+* [**igly.ai**](https://igly.ai) — image editing for background removal, inpainting, and upscaling.
 
 ### Video & Audio
 


### PR DESCRIPTION
Adds igly.ai to the Image Generation & Design section. It is a focused AI image editing tool for background removal, inpainting, and upscaling, so it fits alongside the existing image/design tools.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is

Checklist:
- Searched for duplicates
- Entry follows the one-line style guide
- Direct homepage link, no affiliate URL
- Added to the relevant image/design section
- Markdown diff passes `git diff --check`