### PR TITLE
Add igly.ai to image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Canva Magic Studio**](https://www.canva.com/magic-studio/) — AI design tools.
 * [**Figma AI / Make**](https://www.figma.com/ai/) — AI in Figma.
 * [**Photoshop Firefly**](https://www.adobe.com/products/photoshop/ai.html) — Adobe's generative fill.
+* [**igly.ai**](https://igly.ai) — AI image editor for background removal, inpainting, upscaling, and generative fill.
 
 ### Video & Audio
 


### PR DESCRIPTION
Adds igly.ai to the Image Generation & Design section with a concise entry for background removal, inpainting, upscaling, and generative fill.\n\nDemo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is