### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**OpenLIT**](https://openlit.io/) — OpenTelemetry-native LLM observability.
 * [**Opik (Comet)**](https://github.com/comet-ml/opik) 🆕 — open-source LLM eval + tracing.
 * [**Inspect AI**](https://inspect.aisi.org.uk/) 🆕 — UK AISI's agent eval framework.
+* [**Future AGI**](https://github.com/future-agi/future-agi) 🆕 — open-source platform for agent simulation, evaluating, tracing, guarding, and auto-improving AI agents.
 
 ---
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the **LLM Ops & Observability** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.