### PR TITLE
Add NotFair to Agent Frameworks & MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**MCP TypeScript SDK**](https://github.com/modelcontextprotocol/typescript-sdk) (12k ⭐) — build MCP servers in TS.
 * [**Awesome MCP Servers**](https://github.com/punkpeye/awesome-mcp-servers) ⭐ (86k ⭐) — community MCP server list.
 * [**FastMCP**](https://github.com/jlowin/fastmcp) (25k ⭐) — Pythonic MCP server framework.
+* [**NotFair**](https://github.com/nowork-studio/NotFair) (2.9k ⭐) — open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 ### Browser & Computer Use 🆕
 


### PR DESCRIPTION
Hi @hades217, thanks for maintaining this list — it's a solid reference.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code skills for marketing work (SEO, GEO, Google Ads, and Meta Ads). It has ~2.9k stars and an MIT license.

What it does: it plugs into Claude Code and connects to live advertising and search data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — letting you run audits, keyword research, schema markup, wasted-spend analysis, and more from the CLI.

I placed it at the bottom of the **Model Context Protocol (MCP)** subsection under **Agent Frameworks & MCP**, since it's an MCP-connected tool and that feels like the most relevant spot.

Happy to adjust the wording, move it to a different section, or trim anything that doesn't fit your style — just let me know.