### PR TITLE
Add UnoRouter to LLM Inference & Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Groq**](https://groq.com/) ⭐ — extremely fast LPU-based inference.
 * [**Fireworks AI**](https://fireworks.ai/) — production inference platform.
 * [**Replicate**](https://replicate.com/) — run open-source models in the cloud.
+* [**UnoRouter**](https://unorouter.com/) — OpenAI-compatible gateway: one API key for 200+ models across OpenAI, Anthropic, Google and more, with usage-based pricing.
 * [**Modal**](https://modal.com/) — serverless GPU for AI workloads.
 * [**RunPod**](https://www.runpod.io/) — GPU cloud for AI.
 * [**Lambda Cloud**](https://lambdalabs.com/) — GPU cloud focused on AI.


### PR DESCRIPTION
UnoRouter is an OpenAI-compatible AI gateway: one API key for 200+ models across OpenAI, Anthropic, Google and more, usage-based pricing. Added among the hosted inference APIs (Together/Groq/Fireworks/Replicate) as a multi-provider aggregator endpoint.

Website: https://unorouter.com