### PR TITLE
Add Open Agent Relay to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Bedrock AgentCore**](https://aws.amazon.com/bedrock/agentcore/) 🆕 — AWS managed agent runtime.
 * [**Letta (formerly MemGPT)**](https://github.com/letta-ai/letta) (22k ⭐) — agents with persistent memory.
 * [**Inspect AI (UK AISI)**](https://inspect.aisi.org.uk/) — agent eval framework from UK AI Safety Institute.
+* [**Open Agent Relay**](https://github.com/ShakespeareLabs/open-agent-relay) — expose local agents as LAN-callable capabilities without moving code or credentials.
 
 ### Model Context Protocol (MCP) 🔥
 


### PR DESCRIPTION
Adds Open Agent Relay to the Agent Frameworks section.

Why it fits: it is an Apache-2.0 CLI for exposing existing local agents as callable capabilities over a trusted LAN while keeping their code, prompts, dependencies, and credentials on the host. This supports practical agent collaboration without moving the underlying implementation.

- [x] Searched for duplicates
- [x] One suggestion only
- [x] Direct repository link
- [x] Short, factual description
- [x] Active project older than 30 days