### PR TITLE
Add Tura to AI Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
-* [Tura](https://github.com/Tura-AI/tura) — Local open-source coding agent with CLI, TUI, GUI, verification, and public benchmarks.
+* [Tura](https://github.com/Tura-AI/tura) — Local, open-source coding agent that understands a repository before changing it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
+* [Tura](https://github.com/Tura-AI/tura) — Local open-source coding agent with CLI, TUI, GUI, verification, and public benchmarks.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -128,6 +128,7 @@
 * [**v0 (Vercel)**](https://v0.dev/) — AI UI 生成（输出 React/Next.js）。
 * [**Lovable**](https://lovable.dev/) — AI 应用搭建。
 * [**Devin (Cognition)**](https://devin.ai/) — 自主 SWE Agent（付费托管）。
+* [Tura](https://github.com/Tura-AI/tura) — 本地开源编程 Agent，提供 CLI、TUI、GUI、验证流程与公开基准测试。
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -128,7 +128,7 @@
 * [**v0 (Vercel)**](https://v0.dev/) — AI UI 生成（输出 React/Next.js）。
 * [**Lovable**](https://lovable.dev/) — AI 应用搭建。
 * [**Devin (Cognition)**](https://devin.ai/) — 自主 SWE Agent（付费托管）。
-* [Tura](https://github.com/Tura-AI/tura) — 本地开源编程 Agent，提供 CLI、TUI、GUI、验证流程与公开基准测试。
+* [Tura](https://github.com/Tura-AI/tura) — 本地开源编程 Agent，在理解仓库后才进行修改。
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds Tura to the AI Coding Tools section in both the English and Chinese READMEs.

## Why does this resource deserve inclusion?

Tura is an active, local-first open-source coding agent written in Rust. It offers CLI, TUI, and GUI interfaces, includes a built-in verification workflow, and publishes reproducible coding-agent benchmark results. The project has been public since May 19, 2026, so it is more than 30 days old.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and abide by [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md)

## Disclosure

- [x] No affiliate/referral link