### PR TITLE
Add AI Router to LLM Inference & Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Fireworks AI**](https://fireworks.ai/) — production inference platform.
 * [**Replicate**](https://replicate.com/) — run open-source models in the cloud.
 * [**UnoRouter**](https://unorouter.com/) — OpenAI-compatible gateway: one API key for 200+ models across OpenAI, Anthropic, Google and more, with usage-based pricing.
+* [**AI Router**](https://ai-router.dev/) - Independent OpenAI-compatible API relay for developer and coding-agent workflows.
 * [**Modal**](https://modal.com/) — serverless GPU for AI workloads.
 * [**RunPod**](https://www.runpod.io/) — GPU cloud for AI.
 * [**Lambda Cloud**](https://lambdalabs.com/) — GPU cloud focused on AI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -206,6 +206,7 @@
 * [**Together AI**](https://www.together.ai/) ⭐ — 开源模型托管 API。
 * [**Groq**](https://groq.com/) ⭐ — LPU 极速推理。
 * [**Cerebras Inference**](https://inference.cerebras.ai/) 🆕 — Wafer-scale 极速推理。
+* [**AI Router**](https://ai-router.dev/cn/) — 面向开发者与 Coding Agent 工作流的独立 OpenAI 兼容 API 中转服务。
 * [**Modal**](https://modal.com/) — 无服务器 GPU。
 * [**腾讯云 TI-ONE**](https://cloud.tencent.com/product/tione) 🇨🇳 — 腾讯云 AI 训练推理平台。
 * [**阿里云 PAI**](https://www.aliyun.com/product/bigdata/learn) 🇨🇳 — 阿里云 AI 平台。


### PR DESCRIPTION
## Summary

- Adds AI Router to the hosted inference section in the English and Chinese READMEs.
- Uses the English root page in `README.md` and the localized `/cn` page in `README.zh.md`.

## Fit

AI Router is an independent OpenAI-compatible API relay for developer and coding-agent workflows, matching the existing hosted API and gateway entries in this section.

## Disclosure

I operate AI Router. Both links are direct project homepages with no affiliate or referral tracking.

The listing intentionally avoids price, credit, model-count, reliability, and availability claims.
