### PR TITLE
Add StructEval to LLM Ops & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**OpenLIT**](https://openlit.io/) — OpenTelemetry-native LLM observability.
 * [**Opik (Comet)**](https://github.com/comet-ml/opik) 🆕 — open-source LLM eval + tracing.
 * [**Inspect AI**](https://inspect.aisi.org.uk/) 🆕 — UK AISI's agent eval framework.
+* [**StructEval**](https://github.com/TIGER-AI-Lab/StructEval) — TMLR 2025 benchmark for LLM structural-output generation across 18 text and renderable formats.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds StructEval to the LLM Ops & Observability section.

## Why does this resource deserve inclusion?

StructEval is a TMLR 2025 benchmark with 2,035 examples spanning 18 text and renderable formats and 44 task types. It evaluates LLM structural-output generation with structural and visual checks.

I maintain StructEval and am submitting this project directly.

This pull request was prepared with assistance from OpenAI Codex. I reviewed and verified the final change.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read CONTRIBUTING.md and abide by CODE_OF_CONDUCT.md

## Disclosure

- [x] No affiliate/referral link