### PR TITLE
Add GPTGeminiGrok.AI to General Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Grok**](https://grok.com/) — xAI's assistant with X integration.
 * [**You.com**](https://you.com/) — AI search and chat.
 * [**Pi (Inflection)**](https://pi.ai/) — empathetic personal AI.
+* [GPTGeminiGrok.AI](https://trygrokai.asia/) — multi-model workspace for GPT, Gemini, Grok, Claude, and AI images.
 
 ### Productivity AI
 


### PR DESCRIPTION
Adds [GPTGeminiGrok.AI](https://trygrokai.asia/) to the General Assistants section.\n\nGPTGeminiGrok.AI is an active multi-model browser workspace for GPT, Gemini, Grok, Claude, and AI image workflows. The direct domain has been registered since January 2026, and the entry uses a neutral description under 100 characters.\n\nDisclosure: I am the creator of the submitted product. This PR adds one README entry, uses no affiliate URL, and changes no existing content.