### PR TITLE
Add Chain of Thought to Podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**The TWIML AI Podcast**](https://twimlai.com/podcast/twimlai/) — This Week in ML & AI.
 * [**Practical AI**](https://changelog.com/practicalai) — applied AI for engineers.
 * [**Machine Learning Street Talk**](https://www.youtube.com/@MachineLearningStreetTalk) — academic ML discussions.
+* [**Chain of Thought**](https://chainofthought.show/) — AI infrastructure and developer tools, hosted by Conor Bronsdon.
 
 ### News Sites
 


### PR DESCRIPTION
## What does this PR do?

Adds Chain of Thought to the Podcasts subsection of News, Newsletters & Podcasts.

## Why does this resource deserve inclusion?

- 66 episodes across three seasons, so well past the 30-day bar.
- It covers the production side the section is light on: inference infrastructure, evals, agent infrastructure, and developer tooling. Latent Space and Practical AI are the nearest listed shows.
- Guests have come from NVIDIA, Google DeepMind, AMD, and Databricks.
- Every episode publishes a full transcript and show notes.

Disclosure: I host the show.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and abide by [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md)

## Disclosure

- [x] No affiliate/referral link, OR
- [ ] Affiliate link is clearly disclosed in the entry with `[affiliate]`
