### PR TITLE
Add Lians to Model Context Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**MCP TypeScript SDK**](https://github.com/modelcontextprotocol/typescript-sdk) (12k ⭐) — build MCP servers in TS.
 * [**Awesome MCP Servers**](https://github.com/punkpeye/awesome-mcp-servers) ⭐ (86k ⭐) — community MCP server list.
 * [**FastMCP**](https://github.com/jlowin/fastmcp) (25k ⭐) — Pythonic MCP server framework.
+* [Lians](https://github.com/Lians-ai/Lians) 🆕 — local-first memory for AI agents through MCP and SDKs.
 
 ### Browser & Computer Use 🆕
 


### PR DESCRIPTION
Adds Lians to the MCP section as a local-first memory layer for AI agents. The project is active, more than 30 days old, Apache-2.0 licensed, documented, and directly usable through its MCP server and SDKs.

- [x] Searched README, issues, and pull requests for duplicates
- [x] One direct GitHub link
- [x] One factual description under 100 characters
- [x] No affiliate link or marketing language

Disclosure: I am a Lians maintainer. This contribution was prepared with AI assistance and reviewed before submission.