### PR TITLE
Add SandBase CLI to LLM Inference & Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**RunPod**](https://www.runpod.io/) — GPU cloud for AI.
 * [**Lambda Cloud**](https://lambdalabs.com/) — GPU cloud focused on AI.
 * [**Cerebras Inference**](https://inference.cerebras.ai/) 🆕 — wafer-scale fastest inference.
+* [SandBase CLI](https://www.sandbase.ai) — CLI and MCP bridge for AI models and APIs, with multimodal generation and sandbox workflows.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds SandBase CLI to the **LLM Inference & Hosting** section.

## Why does this resource deserve inclusion?

SandBase CLI provides a CLI and MCP bridge for accessing AI models and APIs, with multimodal generation and sandbox workflows. It is Apache-2.0 licensed, has been public for about 50 days, remains actively maintained, includes setup and command documentation, and has a published npm package. Its combined terminal and MCP interface distinguishes it from the existing browser-first or raw API entries.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and abide by [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md)

## Disclosure

- [x] No affiliate/referral link, OR
- [ ] Affiliate link is clearly disclosed in the entry with `[affiliate]`

Validation: `git diff --check` passes. `npx --yes awesome-lint` reports 674 errors and 5 warnings already present on the upstream base (missing badge/topics, duplicate links, table alignment, and existing em-dash style); the SandBase line follows this repository's documented style and adds no distinct lint category.

Affiliation disclosure: I am affiliated with SandBase. This contribution and its wording were prepared with AI assistance and manually verified against the repository, package metadata, and GitHub timestamps.
