### PR TITLE
Add Agent QA to Browser & Computer Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Skyvern**](https://github.com/Skyvern-AI/skyvern) (22k ⭐) — automate browser workflows with vision LLMs.
 * [**Playwright MCP**](https://github.com/microsoft/playwright-mcp) (32k ⭐) — Playwright as an MCP server.
 * [**Stagehand (Browserbase)**](https://github.com/browserbase/stagehand) (22k ⭐) — Playwright + AI for reliable agents.
+* [Agent QA](https://github.com/vostride/agent-qa) — source-available QA agent for natural-language web and mobile tests.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -163,6 +163,7 @@
 * [**Browser Use**](https://github.com/browser-use/browser-use) (92k ⭐) — Agent 浏览器自动化。
 * [**Skyvern**](https://github.com/Skyvern-AI/skyvern) (22k ⭐) — 视觉 LLM 浏览器自动化。
 * [**Stagehand (Browserbase)**](https://github.com/browserbase/stagehand) (22k ⭐) — Playwright + AI 可靠 Agent。
+* [Agent QA](https://github.com/vostride/agent-qa) — 源码可用的 QA Agent，用自然语言执行 Web 与移动端测试。
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Add Agent QA to the **Browser & Computer Use** section in the English and Chinese READMEs.

## Why does this resource deserve inclusion?

Agent QA runs natural-language web and mobile tests and retains test memory and evidence across runs. It has been public since May 2026, was updated in August 2026, and currently has 772 GitHub stars.

The entry says `source-available` because Agent QA currently uses FSL-1.1-ALv2, which converts to Apache-2.0 after two years.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and abide by [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md)

## Disclosure

- [x] No affiliate/referral link
- [ ] Affiliate link is clearly disclosed in the entry with `[affiliate]`

## Validation

- `git diff --check`
- English description: 68 characters
- standard awesome-lint run; the repository already uses its required em-dash style, which awesome-lint flags, alongside 673 repository-wide errors and 5 warnings
