### PR TITLE
Add AILesson to Courses & Learning Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**LLM Bootcamp (Full Stack DL)**](https://fullstackdeeplearning.com/llm-bootcamp/) — practical LLM app dev.
 * [**Generative AI for Everyone**](https://www.deeplearning.ai/courses/generative-ai-for-everyone/) — *Andrew Ng* — non-technical intro.
 * [**CS336: Language Modeling from Scratch**](https://stanford-cs336.github.io/) — *Stanford* — build a real LLM.
+* [**AILesson**](https://ailesson.io/) — short interactive AI courses for beginners and practical learners.
 
 ### Career-focused Bootcamps
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -285,6 +285,7 @@
 * [**LangChain Academy**](https://academy.langchain.com/) — LangChain / LangGraph 课。
 * [**CS336: 从零搭语言模型**](https://stanford-cs336.github.io/) — *Stanford*。
 * [**3Blue1Brown 神经网络**](https://www.3blue1brown.com/topics/neural-networks) — 视觉直觉。
+* [**AI 小课**](https://ailesson.io/zh) — 面向初学者的短篇互动 AI 课程与实用练习。
 
 ### 中文学习平台 🇨🇳
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -285,7 +285,7 @@
 * [**LangChain Academy**](https://academy.langchain.com/) — LangChain / LangGraph 课。
 * [**CS336: 从零搭语言模型**](https://stanford-cs336.github.io/) — *Stanford*。
 * [**3Blue1Brown 神经网络**](https://www.3blue1brown.com/topics/neural-networks) — 视觉直觉。
-* [**AI 小课**](https://ailesson.io/zh) — 面向初学者的短篇互动 AI 课程与实用练习。
+* [**AI 小课**](https://ailesson.io/zh) — 面向初学者的互动 AI 课程和练习。
 
 ### 中文学习平台 🇨🇳
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the checklist below.
For style and contribution rules, see CONTRIBUTING.md.
-->

## What does this PR do?

Adds AILesson to the Modern LLM / Generative AI section in both the English and Simplified Chinese READMEs.

## Why does this resource deserve inclusion?

AILesson provides short, interactive lessons that help beginners build practical AI skills through guided exercises and immediate feedback.

Its course catalog covers AI fundamentals, ChatGPT, generative AI, agent skills, vibe coding, and practical work and everyday use cases. The resource is actively maintained, offers a beginner-focused learn-by-doing format, and has been publicly available for more than 30 days.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and abide by [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md)

## Disclosure

- [x] No affiliate/referral link, OR
- [ ] Affiliate link is clearly disclosed in the entry with `[affiliate]`