### PR TITLE
Add Zero to AI-Native to Free Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [Made With ML](https://madewithml.com/) — production ML foundations.
 * [AI Engineer Roadmap](https://roadmap.sh/ai-engineer) — community-curated path.
 * [Awesome MLOps](https://github.com/visenger/awesome-mlops) — production ML resources.
+* [Zero to AI-Native](https://www.zerotoainative.xyz/) — open-source curriculum of primary-source AI reads, sequenced across eight modules.
 
 ---
 


### PR DESCRIPTION
Adds Zero to AI-Native to Courses & Learning Paths > Free Aggregators, alongside Made With ML and the AI Engineer Roadmap.

Why it belongs here: it's a curated aggregator itself, not a single course. Open-source, sequenced curriculum (https://www.zerotoainative.xyz) across eight modules (foundations, prompting, retrieval, context engineering, agents, evals, production, safety), with every catalog entry linking to the original lab, author, or institution rather than a rehost. Launched well over 30 days ago, actively maintained. I'm the maintainer, disclosing per your contribution guidelines.

Repo: https://github.com/tushaarmehtaa/zero-to-ai-native