### PR TITLE
Add `AI Talks` to Events & Conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**OpenAI DevDay**](https://devday.openai.com/) — OpenAI developer event.
 * [**Hugging Face Events**](https://huggingface.co/events) — community events.
 * [**Build Club Sydney**](https://www.buildclub.ai/) 🇦🇺 — AU AI builders.
+* [**AI Talks**](https://aietalks.com/) — searchable summaries of AI Engineer talks by topic and event.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds AI Talks to the Events & Conferences section.

## Why does this resource deserve inclusion?

AI Talks is an active, free archive of AI Engineer talks with searchable summaries and navigation by topic and event. It complements the existing AI Engineer Summit / World's Fair entry by helping readers find and understand individual talks.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read CONTRIBUTING.md and abide by CODE_OF_CONDUCT.md

## Disclosure

- [x] No affiliate/referral link
