### PR TITLE
Add Superagent to AI Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
+* [**Superagent**](https://github.com/pungme/superagent-desktop) — open-source macOS desktop app giving Claude Code and Codex a real browser to drive, an iOS Simulator, and a phone companion app.
 
 ---
 


### PR DESCRIPTION
Adds Superagent to AI Coding Tools.

Open-source (MIT) macOS desktop app that gives Claude Code and Codex a real browser to drive, an iOS Simulator to install and screenshot apps in, and a phone companion app for remote monitoring.

Repo: https://github.com/pungme/superagent-desktop