### PR TITLE
Add LLM Pulse to AI Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [Exa](https://exa.ai/) — search engine designed for AI/LLMs.
 * [Tavily](https://tavily.com/) — search API for agents.
 * [Linkup](https://www.linkup.so/) 🆕 — AI-grade search API.
+* [LLM Pulse](https://llmpulse.ai/) — Tracks brand mentions, citations, sentiment, and share of voice across AI search.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds LLM Pulse to the AI Search section.

## Why does this resource deserve inclusion?

LLM Pulse adds an AI search measurement use case to a section currently focused on search engines and APIs. It tracks brand mentions, citations, sentiment, and share of voice across AI search. The product has been public for more than 30 days.

## Checklist

- [x] One suggestion per PR (multiple = multiple PRs)
- [x] Searched README to confirm no duplicate
- [x] Entry follows style guide: `* [Name](url) — short description`
- [x] Direct link to homepage (not affiliate / redirect)
- [x] Description is ≤ 100 chars, no marketing language
- [x] Added to the correct section
- [x] Trailing whitespace stripped
- [x] I read CONTRIBUTING.md and abide by CODE_OF_CONDUCT.md

## Disclosure

- [x] No affiliate/referral link

Disclosure: I am a co-founder of LLM Pulse.