### PR TITLE
Add AI Weekly to Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Ben's Bites**](https://www.bensbites.com/) — daily AI news for non-technical readers.
 * [**One Useful Thing (Ethan Mollick)**](https://www.oneusefulthing.org/) — practical AI essays.
 * [**Interconnects (Nathan Lambert)**](https://www.interconnects.ai/) — open-source AI commentary.
+* [**AI Weekly**](https://aiweekly.co) — Ranked digest of what influential AI experts read and share.
 
 ### Podcasts
 


### PR DESCRIPTION
Adds AI Weekly to News, Newsletters & Podcasts. The entry is a direct canonical link, under 100 characters, and uses factual language. AI Weekly has operated since 2015 and ranks what influential AI experts and organizations read and share. Disclosure: I am affiliated with AI Weekly.