### PR TITLE
Add YYLO to AI Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
+* [YYLO](https://github.com/yylo-dev/yylo) — Open-source command-line orchestrator for coding agents; per-task worktrees with typed merge gates.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **YYLO** to the `## 💻 AI Coding Tools` section.

YYLO is an open-source (MIT) command-line orchestrator for coding agents, installable via npm as [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli). Each task runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, and a risk-based merge queue owns review. YYLO orchestrates existing coding agents (Pi and Codex subagents) rather than replacing them, so it sits naturally alongside the CLIs already in this section (Claude Code, Codex CLI, Aider, Cline).

## Checklist (per CONTRIBUTING)

- [x] Active project — created 2026-01-06 (well past the 30-day launch window), last pushed 2026-09-03, continuous development
- [x] Open source (MIT) — direct canonical repo link, no affiliate/tracking parameters
- [x] One line, description ≤ 100 chars, factual (no marketing language)
- [x] Bottom of the relevant section, house `* [Name](url) — description.` format
- [x] Not a duplicate (no existing YYLO entry)

## Disclosure

I'm on the YYLO team, and this PR was prepared with an AI coding agent and reviewed by me. For context on traction: ~560 npm downloads/month and 57 GitHub stars. Happy to adjust the description or move it to another section if `AI Coding Tools` isn't the right home — `Agent Frameworks` also crossed my mind, but YYLO is a working CLI rather than a library.
