### PR TITLE
Add OrcaReplay to AI Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
-* [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) 🆕 — records a coding-agent run below the harness and replays it offline byte-for-byte, or forks it from a checkpoint onto another model.
+* [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) 🆕 — records a coding-agent run below the harness and replays it offline with the network off, or forks it from a checkpoint onto another model.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Contributions welcome — open a PR or [start a discussion](https://github.com/h
 * [**Lovable**](https://lovable.dev/) — AI app builder.
 * [**Replit Agent**](https://replit.com/) — AI app generation in Replit.
 * [**Deepnote**](https://deepnote.com/) — AI-first Jupyter alternative with native data integrations and a built-in agent.
+* [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) 🆕 — records a coding-agent run below the harness and replays it offline byte-for-byte, or forks it from a checkpoint onto another model.
 
 ---
 


### PR DESCRIPTION
Adds OrcaReplay to **AI Coding Tools**.

The section is agents that write code; this is the tool for when one of them writes the wrong thing. It records the session below the harness — model traffic, shell commands with their exit codes, per-turn file changes and MCP calls on one timeline — then replays it offline with the network off, reproducing the run byte-for-byte, or forks it from a checkpoint onto a different model so you can see what another one would have decided from the same state.

It sits under several tools already listed here: Claude Code, Cursor, Codex CLI. It also handles harnesses that read no base-URL variable at all, so a Codex CLI signed in with a ChatGPT subscription is still capturable.

Format matches the section: bold link, 🆕 marker, em-dash description. Apache-2.0, `npm i -g orcareplay`. Nine days old at 150 stars, so no ⭐/🔥 marker claimed.
